### PR TITLE
Add Whisper STT service integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,29 @@
+# Ollama LLM
+OLLAMA_MODEL=tinyllama
+
+# Ollama API
+# OLLAMA_API_URL=http://localhost:11434
+OLLAMA_API_URL=http://ollama:11434
+
+# ChromaDB
+# CHROMADB_URL=http://localhost:8000
+CHROMADB_URL=http://chromadb:8000
+
+# Piper TTS
+# PIPER_TTS_URL=http://localhost:8080
+PIPER_TTS_URL=http://lama_tts:8080
+
+# Whisper STT
+# WHISPER_STT_URL=http://localhost:8081
+WHISPER_STT_URL=http://lama_stt:8081
+
+# MySQL
+MYSQL_HOST=lama_mysql
+# MYSQL_HOST=localhost
+MYSQL_DATABASE=lamalamadb
+MYSQL_PORT=3306
+MYSQL_USERNAME=root
+MYSQL_PASSWORD=
+
+# MySQL specific envs
+MYSQL_ALLOW_EMPTY_PASSWORD=yes

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@nestjs/schedule": "^6.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "axios": "^1.8.4",
+    "form-data": "^4.0.0",
     "chromadb": "^2.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/backend/src/api/api.module.ts
+++ b/backend/src/api/api.module.ts
@@ -18,6 +18,7 @@ import { ImageModule } from './image/image.module';
 import { ModelsModule } from './models/models.module';
 import { TtsModelModule } from './tts/tts-model.module';
 import { TtsModule } from './tts-old/tts.module';
+import { SttModule } from './stt/stt.module';
 import { UtilsModule } from './utils/utils.module';
 import { ApiController } from './api.controller';
 import { ApiService } from './api.service';
@@ -53,6 +54,7 @@ import { ApiService } from './api.service';
         OllamaModule,
         TtsModule,
         TtsModelModule,
+        SttModule,
         RagModule,
     ],
     controllers: [ApiController],

--- a/backend/src/api/stt/stt.controller.ts
+++ b/backend/src/api/stt/stt.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+import { SttService } from './stt.service';
+
+@Controller('api/stt')
+export class SttController {
+    constructor(private readonly sttService: SttService) {}
+
+    @Post()
+    @UseInterceptors(FileInterceptor('file'))
+    public async transcribe(@UploadedFile() file: Express.Multer.File) {
+        const text = await this.sttService.transcribe(file);
+        return { text };
+    }
+}

--- a/backend/src/api/stt/stt.module.ts
+++ b/backend/src/api/stt/stt.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { SttController } from './stt.controller';
+import { SttService } from './stt.service';
+
+@Module({
+    controllers: [SttController],
+    providers: [SttService],
+    exports: [SttService],
+})
+export class SttModule {}

--- a/backend/src/api/stt/stt.service.ts
+++ b/backend/src/api/stt/stt.service.ts
@@ -1,0 +1,28 @@
+import { HttpException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import FormData from 'form-data';
+
+@Injectable()
+export class SttService {
+    private readonly WHISPER_STT_URL: string;
+
+    constructor(private readonly configService: ConfigService) {
+        this.WHISPER_STT_URL = this.configService.get<string>('WHISPER_STT_URL') || '';
+    }
+
+    public async transcribe(file: Express.Multer.File): Promise<string> {
+        if (!file) {
+            throw new HttpException('Missing audio file', 400);
+        }
+
+        const formData = new FormData();
+        formData.append('file', file.buffer, file.originalname);
+
+        const headers = formData.getHeaders();
+        const requestUrl: string = this.WHISPER_STT_URL + '/stt';
+        const response = await axios.post(requestUrl, formData, { headers });
+
+        return response.data.text || '';
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,14 @@ services:
     volumes:
       - tts-data:/app/model
 
+  lama_stt:
+    container_name: lama_stt
+    build: ./whisper-stt
+    ports:
+      - '8081:8081'
+    volumes:
+      - stt-data:/root/.cache/whisper
+
 volumes:
   ollama-data:
     name: lama_ollama_volume
@@ -78,5 +86,7 @@ volumes:
     name: lama_frontend_volume
   tts-data:
     name: lama_tts_volume
+  stt-data:
+    name: lama_stt_volume
   mysql_data:
     name: lama_mysql_volume

--- a/whisper-stt/Dockerfile
+++ b/whisper-stt/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y ffmpeg nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Whisper
+RUN pip install --no-cache-dir openai-whisper
+
+# Create app directory
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 8081
+
+CMD ["npm", "start"]

--- a/whisper-stt/package.json
+++ b/whisper-stt/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "whisper-stt-api",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5"
+  }
+}

--- a/whisper-stt/server.js
+++ b/whisper-stt/server.js
@@ -1,0 +1,37 @@
+import express from 'express';
+import multer from 'multer';
+import { spawn } from 'child_process';
+import fs from 'fs';
+
+const PORT = 8081;
+const upload = multer({ dest: '/tmp' });
+
+const app = express();
+
+app.post('/stt', upload.single('file'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).send('No file uploaded.');
+  }
+
+  const inputPath = req.file.path;
+  const outputPath = `${inputPath}.txt`;
+
+  const whisper = spawn('whisper', [inputPath, '--model', 'base', '--output_format', 'txt', '--output_dir', '/tmp']);
+
+  whisper.on('close', (code) => {
+    if (code !== 0) {
+      fs.unlinkSync(inputPath);
+      return res.status(500).send('Whisper failed with code ' + code);
+    }
+    fs.readFile(outputPath, 'utf8', (err, data) => {
+      fs.unlinkSync(inputPath);
+      if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
+      if (err) {
+        return res.status(500).send('Failed to read transcription');
+      }
+      res.json({ text: data.trim() });
+    });
+  });
+});
+
+app.listen(PORT, () => console.log(`Whisper STT API running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add Whisper speech-to-text service with Docker image and Express server
- expose `lama_stt` container in docker-compose
- add example environment variable `WHISPER_STT_URL`
- implement STT controller, service and module for backend
- include new module in NestJS `ApiModule`
- add `form-data` dependency for backend

## Testing
- `node --version`
