### PR TITLE
Add speech-to-text page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,10 @@
 # Lama Lama AI
 
 Frontend layer of Lama Lama AI application
+
+## Speech-to-Text
+
+The STT page records audio from your microphone. Your browser will prompt you to
+grant microphone access when recording is started. You must allow this
+permission in order for transcription to work. If access is denied, adjust the
+permission settings in your browser.

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -3,3 +3,4 @@ export * from './home/Home';
 export * from './image-analysis/ImageAnalysis';
 export * from './settings/Settings';
 export * from './upload-data/UploadData';
+export * from './stt/Stt';

--- a/frontend/src/pages/stt/Stt.tsx
+++ b/frontend/src/pages/stt/Stt.tsx
@@ -1,0 +1,81 @@
+import { JSX, useRef, useState } from 'react';
+
+import { Box, Button, Card, Paper } from '@mui/material';
+import Typography from '@mui/material/Typography';
+
+import { API_BASE_URL } from '../../shared/constants';
+
+export function Stt(): JSX.Element {
+    const [recording, setRecording] = useState(false);
+    const [transcription, setTranscription] = useState('');
+    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+    const chunksRef = useRef<Blob[]>([]);
+
+    const startRecording = async () => {
+        setTranscription('');
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            const mediaRecorder = new MediaRecorder(stream);
+            mediaRecorderRef.current = mediaRecorder;
+            chunksRef.current = [];
+
+            mediaRecorder.ondataavailable = (event: BlobEvent) => {
+                if (event.data.size > 0) {
+                    chunksRef.current.push(event.data);
+                }
+            };
+
+            mediaRecorder.onstop = async () => {
+                const audioBlob = new Blob(chunksRef.current, { type: 'audio/webm' });
+                await uploadAudio(audioBlob);
+                stream.getTracks().forEach((track) => track.stop());
+            };
+
+            mediaRecorder.start();
+            setRecording(true);
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
+    const stopRecording = () => {
+        if (mediaRecorderRef.current && recording) {
+            mediaRecorderRef.current.stop();
+            setRecording(false);
+        }
+    };
+
+    const uploadAudio = async (blob: Blob) => {
+        const formData = new FormData();
+        formData.append('file', blob, 'recording.webm');
+        try {
+            const response = await fetch(`${API_BASE_URL}/stt`, {
+                method: 'POST',
+                body: formData,
+            });
+            const data = await response.json();
+            setTranscription(data.text ?? '');
+        } catch (err: any) {
+            console.error(err);
+            setTranscription(err.toString());
+        }
+    };
+
+    return (
+        <Box pt={2}>
+            <Paper elevation={1}>
+                <Card sx={{ padding: 1 }}>
+                    <Typography mb={2} variant={'h5'}>Speech To Text</Typography>
+                    <Button variant='contained' onClick={recording ? stopRecording : startRecording}>
+                        {recording ? 'Stop recording' : 'Start recording'}
+                    </Button>
+                    {transcription && (
+                        <Box mt={2}>
+                            <Typography variant={'body1'}>{transcription}</Typography>
+                        </Box>
+                    )}
+                </Card>
+            </Paper>
+        </Box>
+    );
+}

--- a/frontend/src/shared/constants/Routes.tsx
+++ b/frontend/src/shared/constants/Routes.tsx
@@ -2,9 +2,10 @@ import ChatIcon from '@mui/icons-material/Chat';
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import HomeIcon from '@mui/icons-material/Home';
 import InsertPhotoIcon from '@mui/icons-material/InsertPhoto';
+import KeyboardVoiceIcon from '@mui/icons-material/KeyboardVoice';
 import SettingsIcon from '@mui/icons-material/Settings';
 
-import { Chat, Home, ImageAnalysis, Settings, UploadData } from '../../pages';
+import { Chat, Home, ImageAnalysis, Settings, UploadData, Stt } from '../../pages';
 import { APP_VIEW } from '../enums';
 import { Route } from '../models';
 
@@ -32,6 +33,12 @@ export const routes: Record<APP_VIEW, Route> = {
         view: APP_VIEW.IMAGE_ANALYSIS,
         page: <ImageAnalysis />,
         icon: <InsertPhotoIcon />,
+    },
+    [APP_VIEW.STT]: {
+        name: 'Speech To Text',
+        view: APP_VIEW.STT,
+        page: <Stt />,
+        icon: <KeyboardVoiceIcon />,
     },
     [APP_VIEW.SETTINGS]: {
         name: 'Settings',

--- a/frontend/src/shared/enums/AppView.enum.ts
+++ b/frontend/src/shared/enums/AppView.enum.ts
@@ -3,5 +3,6 @@ export enum APP_VIEW {
     CHAT,
     UPLOAD_DATA,
     IMAGE_ANALYSIS,
-    SETTINGS
+    SETTINGS,
+    STT
 }


### PR DESCRIPTION
## Summary
- add STT to AppView enum
- implement a new `/stt` page with recording and transcription upload
- expose the STT page in routes and page exports
- document microphone permission requirement in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in backend *(fails: jest not found)*