### PR TITLE
Add chat history page and hook

### DIFF
--- a/frontend/src/hooks/useFetchChatHistory.ts
+++ b/frontend/src/hooks/useFetchChatHistory.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { API_BASE_URL } from '../shared/constants';
+import { ChatHistory } from '../shared/models';
+
+export const useFetchChatHistory = (limit = 20, autoFetch = true) => {
+    const [data, setData] = useState<ChatHistory[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchHistory = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetch(`${API_BASE_URL}/history?limit=${limit}`);
+            const json: ChatHistory[] = await res.json();
+            setData(json ?? []);
+        } catch (err: any) {
+            console.error(err);
+            setError(err.toString());
+        } finally {
+            setLoading(false);
+        }
+    }, [limit]);
+
+    useEffect(() => {
+        if (autoFetch) {
+            fetchHistory();
+        }
+    }, [autoFetch, fetchHistory]);
+
+    return { data, loading, error };
+};

--- a/frontend/src/pages/history/History.tsx
+++ b/frontend/src/pages/history/History.tsx
@@ -1,0 +1,78 @@
+import { JSX } from 'react';
+import {
+    Box,
+    Card,
+    Paper,
+    Typography,
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableBody,
+    Button,
+} from '@mui/material';
+
+import { API_BASE_URL } from '../../shared/constants';
+import { useFetchChatHistory } from '../../hooks/useFetchChatHistory';
+
+export function History(): JSX.Element {
+    const { data, loading, error } = useFetchChatHistory();
+
+    const deleteHistory = async () => {
+        try {
+            await fetch(`${API_BASE_URL}/history`, { method: 'DELETE' });
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
+    return (
+        <Box pt={2}>
+            <Paper elevation={1}>
+                <Card sx={{ padding: 1 }}>
+                    <Typography mb={2} variant={'h5'}>
+                        History
+                    </Typography>
+                    {loading && (
+                        <Typography variant={'body1'}>Loading...</Typography>
+                    )}
+                    {error && (
+                        <Typography variant={'body1'}>{error}</Typography>
+                    )}
+                    {data.length > 0 && (
+                        <Table size={'small'}>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>Question</TableCell>
+                                    <TableCell>Answer</TableCell>
+                                    <TableCell>Model</TableCell>
+                                    <TableCell>Created</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {data.map((msg) => (
+                                    <TableRow key={msg.id}>
+                                        <TableCell>{msg.userQuestion}</TableCell>
+                                        <TableCell>{msg.modelAnswer}</TableCell>
+                                        <TableCell>{msg.modelName}</TableCell>
+                                        <TableCell>
+                                            {new Date(msg.createdAt).toLocaleString()}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                    {data.length === 0 && !loading && (
+                        <Typography variant={'body1'}>No history</Typography>
+                    )}
+                    <Box mt={2}>
+                        <Button variant={'contained'} color={'error'} onClick={deleteHistory}>
+                            Delete All
+                        </Button>
+                    </Box>
+                </Card>
+            </Paper>
+        </Box>
+    );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -4,3 +4,4 @@ export * from './image-analysis/ImageAnalysis';
 export * from './settings/Settings';
 export * from './upload-data/UploadData';
 export * from './stt/Stt';
+export * from './history/History';

--- a/frontend/src/shared/constants/Routes.tsx
+++ b/frontend/src/shared/constants/Routes.tsx
@@ -1,11 +1,12 @@
 import ChatIcon from '@mui/icons-material/Chat';
+import HistoryIcon from '@mui/icons-material/History';
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import HomeIcon from '@mui/icons-material/Home';
 import InsertPhotoIcon from '@mui/icons-material/InsertPhoto';
 import KeyboardVoiceIcon from '@mui/icons-material/KeyboardVoice';
 import SettingsIcon from '@mui/icons-material/Settings';
 
-import { Chat, Home, ImageAnalysis, Settings, UploadData, Stt } from '../../pages';
+import { Chat, History, Home, ImageAnalysis, Settings, UploadData, Stt } from '../../pages';
 import { APP_VIEW } from '../enums';
 import { Route } from '../models';
 
@@ -21,6 +22,12 @@ export const routes: Record<APP_VIEW, Route> = {
         view: APP_VIEW.CHAT,
         page: <Chat />,
         icon: <ChatIcon />,
+    },
+    [APP_VIEW.HISTORY]: {
+        name: 'History',
+        view: APP_VIEW.HISTORY,
+        page: <History />,
+        icon: <HistoryIcon />,
     },
     [APP_VIEW.UPLOAD_DATA]: {
         name: 'Upload Data',

--- a/frontend/src/shared/enums/AppView.enum.ts
+++ b/frontend/src/shared/enums/AppView.enum.ts
@@ -1,6 +1,7 @@
 export enum APP_VIEW {
     HOME,
     CHAT,
+    HISTORY,
     UPLOAD_DATA,
     IMAGE_ANALYSIS,
     SETTINGS,

--- a/frontend/src/shared/models/ChatHistory.model.ts
+++ b/frontend/src/shared/models/ChatHistory.model.ts
@@ -1,0 +1,7 @@
+export interface ChatHistory {
+    id: number;
+    userQuestion: string;
+    modelAnswer: string;
+    modelName: string;
+    createdAt: Date;
+}

--- a/frontend/src/shared/models/index.ts
+++ b/frontend/src/shared/models/index.ts
@@ -2,3 +2,4 @@ export * from './BackgroundTask.model';
 export * from './LlmImage.model';
 export * from './RagAskResponse.model';
 export * from './Route.model';
+export * from './ChatHistory.model';


### PR DESCRIPTION
## Summary
- create ChatHistory model
- add hook for fetching chat history
- implement History page to display saved chat messages
- expose History page exports and route
- update `APP_VIEW` enum and navigation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in backend *(fails: jest not found)*