### PR TITLE
Implement RAG document management panel

### DIFF
--- a/backend/src/api/api.module.ts
+++ b/backend/src/api/api.module.ts
@@ -6,13 +6,14 @@ import { OllamaModule } from 'src/services/ollama/ollama.module';
 import { RagModule } from 'src/services/rag/rag.module';
 
 import databaseRegisteredConfig, { DatabaseConfig, defaultDatabaseConfig } from '../config/database.config';
-import { ChatHistoryEntity, LlmModelEntity, ProcessedFile } from '../entities';
+import { ChatHistoryEntity, LlmModelEntity, ProcessedFile, DocumentEntity } from '../entities';
 import { HeaderMiddleware } from '../middleware/header.middleware';
 import { LoggerMiddleware } from '../middleware/logger.middleware';
 import { ScannerModule } from '../services/scanner/scanner.module';
 
 import { ChatModule } from './chat/chat.module';
 import { DataModule } from './data/data.module';
+import { DocumentsModule } from './documents/documents.module';
 import { HistoryModule } from './history/history.module';
 import { ImageModule } from './image/image.module';
 import { ModelsModule } from './models/models.module';
@@ -37,7 +38,7 @@ import { ApiService } from './api.service';
                     username: dbConfig.username,
                     password: dbConfig.password,
                     database: dbConfig.database,
-                    entities: [ChatHistoryEntity, LlmModelEntity, ProcessedFile],
+                    entities: [ChatHistoryEntity, LlmModelEntity, ProcessedFile, DocumentEntity],
                     synchronize: true,
                     // logging: true,
                     // logger: 'advanced-console',
@@ -47,6 +48,7 @@ import { ApiService } from './api.service';
         ScheduleModule.forRoot(),
         ChatModule,
         DataModule,
+        DocumentsModule,
         HistoryModule,
         ImageModule,
         ModelsModule,

--- a/backend/src/api/data/data.controller.ts
+++ b/backend/src/api/data/data.controller.ts
@@ -15,10 +15,10 @@ export class DataController {
         this.logger.log(
             `Received ${file.originalname} file (${Math.floor(file.size / 1024).toString()} kb) with documentId: ${documentId}.`,
         );
-        await this.dataService.putDataFileIntoDatabase(file, documentId);
+        const doc = await this.dataService.putDataFileIntoDatabase(file, documentId);
         return {
             message: `File ${file.originalname} uploaded successfully.`,
-            fileName: '',
+            documentId: doc.id,
             code: 200,
         };
     }

--- a/backend/src/api/data/data.module.ts
+++ b/backend/src/api/data/data.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { RagModule } from '../../services/rag/rag.module';
+import { DocumentsModule } from '../documents/documents.module';
 
 import { DataController } from './data.controller';
 import { DataService } from './data.service';
 
 @Module({
-    imports: [RagModule],
+    imports: [RagModule, DocumentsModule],
     controllers: [DataController],
     providers: [DataService],
 })

--- a/backend/src/api/data/data.service.ts
+++ b/backend/src/api/data/data.service.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@nestjs/common';
 
 import { RagService } from '../../services/rag/rag.service';
+import { DocumentsService } from '../documents/documents.service';
 
 @Injectable()
 export class DataService {
-    constructor(private ragService: RagService) {}
+    constructor(
+        private ragService: RagService,
+        private documentsService: DocumentsService,
+    ) {}
 
     public async putDataFileIntoDatabase(file: Express.Multer.File, documentId: string) {
         const content: string = file.buffer.toString('utf-8');
-        return await this.ragService.addDocument(content, documentId);
+        const source = await this.ragService.addDocument(content, documentId);
+        return await this.documentsService.create(documentId, source, content);
     }
 }

--- a/backend/src/api/documents/documents.controller.ts
+++ b/backend/src/api/documents/documents.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Delete, Get, Param } from '@nestjs/common';
+
+import { DocumentEntity } from '../../entities';
+import { DocumentsService } from './documents.service';
+
+@Controller('api/documents')
+export class DocumentsController {
+    constructor(private readonly documentsService: DocumentsService) {}
+
+    @Get()
+    async findAll(): Promise<DocumentEntity[]> {
+        return await this.documentsService.findAll();
+    }
+
+    @Delete(':id')
+    async remove(@Param('id') id: string): Promise<void> {
+        await this.documentsService.remove(Number(id));
+    }
+}

--- a/backend/src/api/documents/documents.module.ts
+++ b/backend/src/api/documents/documents.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { DocumentEntity } from '../../entities';
+import { RagModule } from '../../services/rag/rag.module';
+import { DocumentsController } from './documents.controller';
+import { DocumentsService } from './documents.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([DocumentEntity]), RagModule],
+    controllers: [DocumentsController],
+    providers: [DocumentsService],
+    exports: [DocumentsService],
+})
+export class DocumentsModule {}

--- a/backend/src/api/documents/documents.service.ts
+++ b/backend/src/api/documents/documents.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { DocumentEntity } from '../../entities';
+import { RagService } from '../../services/rag/rag.service';
+
+@Injectable()
+export class DocumentsService {
+    constructor(
+        @InjectRepository(DocumentEntity)
+        private readonly documentRepository: Repository<DocumentEntity>,
+        private readonly ragService: RagService,
+    ) {}
+
+    async create(title: string, source: string, description: string): Promise<DocumentEntity> {
+        const doc = this.documentRepository.create({ title, source, description });
+        return await this.documentRepository.save(doc);
+    }
+
+    async findAll(): Promise<DocumentEntity[]> {
+        return await this.documentRepository.find({ order: { createdAt: 'DESC' } });
+    }
+
+    async remove(id: number): Promise<void> {
+        const doc = await this.documentRepository.findOne({ where: { id } });
+        if (doc) {
+            await this.documentRepository.delete(id);
+            try {
+                await this.ragService.deleteDocument(doc.source);
+            } catch (err) {
+                // log and ignore
+            }
+        }
+    }
+}

--- a/backend/src/services/rag/rag.service.ts
+++ b/backend/src/services/rag/rag.service.ts
@@ -54,7 +54,7 @@ export class RagService implements OnModuleInit {
         }
     }
 
-    public async addDocument(content: string, documentId: string): Promise<void> {
+    public async addDocument(content: string, documentId: string): Promise<string> {
         const normalizedDocumentId: string = documentId ? this.normalizeDocumentId(documentId) : uuidV4();
 
         this.logger.log(`Set document ID to ${normalizedDocumentId}.`);
@@ -65,9 +65,15 @@ export class RagService implements OnModuleInit {
         await this.collection.add({
             documents: chunks,
             ids,
+            metadatas: chunks.map(() => ({ docId: normalizedDocumentId })),
         });
 
         this.logger.log(`Added ${chunks.length} chunks to collection.`);
+        return normalizedDocumentId;
+    }
+
+    public async deleteDocument(docId: string): Promise<void> {
+        await this.collection.delete({ where: { docId } });
     }
 
     public async retrieveContextFromDatabase(chatQuestion: ChatQuestionDto): Promise<string[]> {

--- a/frontend/src/components/document/DocumentList.tsx
+++ b/frontend/src/components/document/DocumentList.tsx
@@ -1,0 +1,74 @@
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    Box,
+    IconButton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    Typography,
+} from '@mui/material';
+import { JSX } from 'react';
+
+import { API_BASE_URL } from '../../shared/constants';
+import { useFetchDocuments } from '../../hooks/useFetchDocuments';
+
+export function DocumentList(): JSX.Element {
+    const { data, loading, error, refresh } = useFetchDocuments();
+
+    const deleteDocument = async (id: number) => {
+        try {
+            await fetch(`${API_BASE_URL}/documents/${id}`, {
+                method: 'DELETE',
+            });
+            await refresh();
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
+    if (loading) {
+        return <Typography variant={'body1'}>Loading...</Typography>;
+    }
+
+    if (error) {
+        return <Typography variant={'body1'}>{error}</Typography>;
+    }
+
+    if (data.length === 0) {
+        return <Typography variant={'body1'}>No documents</Typography>;
+    }
+
+    return (
+        <Box mt={2}>
+            <Table size={'small'}>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Title</TableCell>
+                        <TableCell>Created</TableCell>
+                        <TableCell></TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {data.map((doc) => (
+                        <TableRow key={doc.id}>
+                            <TableCell>{doc.title}</TableCell>
+                            <TableCell>
+                                {new Date(doc.createdAt).toLocaleString()}
+                            </TableCell>
+                            <TableCell>
+                                <IconButton
+                                    aria-label={'delete'}
+                                    onClick={() => deleteDocument(doc.id)}
+                                >
+                                    <DeleteIcon />
+                                </IconButton>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </Box>
+    );
+}

--- a/frontend/src/hooks/useFetchDocuments.ts
+++ b/frontend/src/hooks/useFetchDocuments.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { API_BASE_URL } from '../shared/constants';
+import { Document } from '../shared/models';
+
+export const useFetchDocuments = (autoFetch = true) => {
+    const [data, setData] = useState<Document[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchDocs = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetch(`${API_BASE_URL}/documents`);
+            const json: Document[] = await res.json();
+            setData(json ?? []);
+        } catch (err: any) {
+            console.error(err);
+            setError(err.toString());
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (autoFetch) {
+            fetchDocs();
+        }
+    }, [autoFetch, fetchDocs]);
+
+    return { data, loading, error, refresh: fetchDocs };
+};

--- a/frontend/src/pages/upload-data/UploadData.tsx
+++ b/frontend/src/pages/upload-data/UploadData.tsx
@@ -1,26 +1,28 @@
 import { JSX } from 'react';
 
-import {
-    Box,
-    Card,
-    Paper,
-} from '@mui/material';
+import { Box, Card, Paper } from '@mui/material';
 import Typography from '@mui/material/Typography';
 
 import { Upload } from '../../components/upload/Upload.tsx';
+import { DocumentList } from '../../components/document/DocumentList.tsx';
 
 export function UploadData(): JSX.Element {
     return (
         <Box pt={2}>
             <Paper elevation={1}>
                 <Card sx={{ padding: 1 }}>
-                    <Typography mb={2} variant={'h5'}>Data training</Typography>
+                    <Typography mb={2} variant={'h5'}>
+                        Data training
+                    </Typography>
                     <Upload
-                        title={'Upload .txt file with text data for AI training'}
+                        title={
+                            'Upload .txt file with text data for AI training'
+                        }
                         buttonText={'Upload file'}
                         acceptType={'.txt'}
                         urlPath={'/data/upload'}
                     />
+                    <DocumentList />
                 </Card>
             </Paper>
         </Box>

--- a/frontend/src/shared/models/Document.model.ts
+++ b/frontend/src/shared/models/Document.model.ts
@@ -1,0 +1,7 @@
+export interface Document {
+    id: number;
+    title: string;
+    source: string;
+    description: string;
+    createdAt: Date;
+}

--- a/frontend/src/shared/models/index.ts
+++ b/frontend/src/shared/models/index.ts
@@ -3,3 +3,4 @@ export * from './LlmImage.model';
 export * from './RagAskResponse.model';
 export * from './Route.model';
 export * from './ChatHistory.model';
+export * from './Document.model';


### PR DESCRIPTION
## Summary
- manage uploaded documents in backend
- return saved document id from upload API
- expose new `/documents` endpoints
- show documents in the Data Training page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839649ff21c83299505f8453a5a69e9